### PR TITLE
Refactor exception use; more jacoco-friendly

### DIFF
--- a/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypeValidatingPredicate.java
+++ b/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypeValidatingPredicate.java
@@ -3,6 +3,7 @@ package no.entur.abt.netex.id.predicate;
 import no.entur.abt.netex.id.DefaultNetexIdValidator;
 import no.entur.abt.netex.id.NetexIdValidatingParser;
 import no.entur.abt.netex.id.NetexIdValidator;
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 
 /*-
  * #%L
@@ -48,20 +49,15 @@ public class NetexIdCodespaceTypeValidatingPredicate extends NetexIdCodespaceTyp
 			// codespace + type is assumed valid
 			// also validate value
 			if(!VALIDATOR.validateValue(t, codespaceColonType.length + 1, t.length())) {
-				throwException(t);
+				throw NetexIdValidatingParser.getException(t);
 			}
 			return true;
 		}
 
 		// validate whole id since we do not get at match on the above test
 		if(!VALIDATOR.validate(t)) {
-			throwException(t);
+			throw NetexIdValidatingParser.getException(t);
 		}
 		return false;
-	}
-
-	// protected so that override in a subclass is possible
-	protected void throwException(CharSequence t) {
-		throw NetexIdValidatingParser.getException(t);
 	}
 }

--- a/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceValidatingPredicate.java
+++ b/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceValidatingPredicate.java
@@ -25,6 +25,7 @@ package no.entur.abt.netex.id.predicate;
 
 import no.entur.abt.netex.id.DefaultNetexIdValidator;
 import no.entur.abt.netex.id.NetexIdValidatingParser;
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 
 public class NetexIdCodespaceValidatingPredicate extends NetexIdCodespacePredicate {
 
@@ -37,14 +38,9 @@ public class NetexIdCodespaceValidatingPredicate extends NetexIdCodespacePredica
     @Override
     public boolean test(CharSequence t) {
         if(!VALIDATOR.validate(t)) {
-            throwException(t);
+            throw NetexIdValidatingParser.getException(t);
         }
         return super.test(t);
-    }
-
-    // protected so that override in a subclass is possible
-    protected void throwException(CharSequence t) {
-        throw NetexIdValidatingParser.getException(t);
     }
 
 }

--- a/src/main/java/no/entur/abt/netex/id/predicate/NetexIdTypeValidatingPredicate.java
+++ b/src/main/java/no/entur/abt/netex/id/predicate/NetexIdTypeValidatingPredicate.java
@@ -25,6 +25,7 @@ package no.entur.abt.netex.id.predicate;
 
 import no.entur.abt.netex.id.DefaultNetexIdValidator;
 import no.entur.abt.netex.id.NetexIdValidatingParser;
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 
 public class NetexIdTypeValidatingPredicate extends NetexIdTypePredicate {
 
@@ -40,20 +41,16 @@ public class NetexIdTypeValidatingPredicate extends NetexIdTypePredicate {
             // type is assumed valid
             // also validate codespace and value
             if(!VALIDATOR.validateCodespace(t, 0, DefaultNetexIdValidator.NETEX_ID_CODESPACE_LENGTH) || !VALIDATOR.validateValue(t, type.length + 1, t.length())) {
-                throwException(t);
+                throw NetexIdValidatingParser.getException(t);
             }
             return true;
         }
 
         // validate whole id since we do not get at match on the above test
         if(!VALIDATOR.validate(t)) {
-            throwException(t);
+            throw NetexIdValidatingParser.getException(t);
         }
         return false;
     }
 
-    // protected so that override in a subclass is possible
-    protected void throwException(CharSequence t) {
-        throw NetexIdValidatingParser.getException(t);
-    }
 }


### PR DESCRIPTION
Coverage reports misses the `throwException` line. 