### PR TITLE
Add template input to non-validating id builder

### DIFF
--- a/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
@@ -22,6 +22,8 @@ package no.entur.abt.netex.id;
  * #L%
  */
 
+import no.entur.abt.netex.utils.IllegalNetexIDException;
+
 /**
  * 
  * Build a Netex id. Does not validate inputs; the caller is responsible for ensuring that
@@ -35,9 +37,27 @@ public class NetexIdNonValidatingBuilder {
 		return new NetexIdNonValidatingBuilder();
 	}
 
+	public static NetexIdNonValidatingBuilder newInstance(String id) {
+		return new NetexIdNonValidatingBuilder(id);
+	}
+
 	protected String codespace;
 	protected String type;
 	protected String value;
+
+	public NetexIdNonValidatingBuilder(String id) {
+		if(id == null) {
+			throw new IllegalArgumentException("Expected id");
+		}
+		// use id as template
+		NetexIdNonvalidatingParser parser = NetexIdNonvalidatingParser.getInstance();
+		codespace = parser.getCodespace(id);
+		type = parser.getType(id);
+		value = parser.getValue(id);
+	}
+
+	public NetexIdNonValidatingBuilder() {
+	}
 
 	public NetexIdNonValidatingBuilder withCodespace(String codespace) {
 		this.codespace = codespace;

--- a/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
@@ -37,6 +37,23 @@ public class NetexIdNonValidatingBuilderTest {
     }
 
     @Test
+    public void testBuilderFromExistingId() {
+        assertEquals("AAA:Network:123", NetexIdNonValidatingBuilder.newInstance("AAA:Network:123").build());
+    }
+
+    @Test
+    public void testBuilderFromExistingIdWithOverride() {
+        assertEquals("AAA:Network:456", NetexIdNonValidatingBuilder.newInstance("AAA:Network:123").withValue("456").build());
+    }
+
+    @Test
+    public void testBuilderFromNullId() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdNonValidatingBuilder.newInstance(null).build();
+        });
+    }
+
+    @Test
     public void testInvalidCodespaceInput() {
         assertThrows(IllegalStateException.class, () -> {
             NetexIdNonValidatingBuilder.newInstance().withType("Network").withValue("123").build();


### PR DESCRIPTION
So feature parity with the corresponding (validating) `NetexIdBuilder`.