### PR TITLE
Create id via builders - one-liners

### DIFF
--- a/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
+++ b/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
@@ -117,21 +117,7 @@ public class DefaultNetexIdValidator implements NetexIdValidator {
 
 	@Override
 	public boolean validate(CharSequence string) {
-		if (string == null) {
-			return false;
-		}
-
-		// minimum size is XXX:X:X
-		if (string.length() < NETEX_ID_MINIMUM_LENGTH) {
-			return false;
-		}
-		if (string.charAt(NETEX_ID_CODESPACE_LENGTH) != NETEX_ID_SEPARATOR_CHAR) {
-			return false;
-		}
-
-		int last = validateTypeToIndex(string, NETEX_ID_CODESPACE_LENGTH + 1);
-		return last != -1 && string.charAt(last) == NETEX_ID_SEPARATOR_CHAR && last > NETEX_ID_CODESPACE_LENGTH + 1 && validateCodespace(string, 0, NETEX_ID_CODESPACE_LENGTH)
-				&& validateValue(string, last + 1, string.length());
+		return validateToValueIndex(string) != -1;
 	}
 
 	protected static int getLastSeperatorIndex(CharSequence string, int startIndex, int endIndex) {

--- a/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
+++ b/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
@@ -201,7 +201,7 @@ public class DefaultNetexIdValidator implements NetexIdValidator {
 
 	/**
 	 *
-	 * Validate codespace and type.
+	 * Validate codespace and type, return index useful for creating an id with the same codespace and type and another value.
 	 *
 	 * @param string netex id
 	 * @return -1 if the id is invalid, otherwise the index of the value part within the id (the character index after the second colon).
@@ -216,21 +216,32 @@ public class DefaultNetexIdValidator implements NetexIdValidator {
 		if (string.length() < NETEX_ID_MINIMUM_LENGTH) {
 			return -1;
 		}
-		if (string.charAt(NETEX_ID_CODESPACE_LENGTH) != ':') {
+		if (string.charAt(NETEX_ID_CODESPACE_LENGTH) != NETEX_ID_SEPARATOR_CHAR) {
 			return -1;
 		}
 
-		int last = validateTypeToIndex(string, NETEX_ID_CODESPACE_LENGTH + 1);
-		if (last == -1 || string.charAt(last) != ':' || last <= NETEX_ID_CODESPACE_LENGTH + 1) {
+		// XXX:AB:CDE
+		// 0123456789
+		//
+		// scan from A at index 4.
+		// Outcomes:
+		// Valid id: For a valid id the first non-valid char should be the second colon (at index 6 in example), with at least one char between it and the colon at index 3.
+		// Invalid id: No non-valid char found, or a non-valid char that is not colon.
+		int typeFirstNonValidCharIndex = validateTypeToIndex(string, NETEX_ID_CODESPACE_LENGTH + 1);
+		if (typeFirstNonValidCharIndex == -1 || string.charAt(typeFirstNonValidCharIndex) != NETEX_ID_SEPARATOR_CHAR || typeFirstNonValidCharIndex <= NETEX_ID_CODESPACE_LENGTH + 1) {
 			return -1;
 		}
+
 		if (!validateCodespace(string, 0, NETEX_ID_CODESPACE_LENGTH)) {
 			return -1;
 		}
-		last++;
-		if (!validateValue(string, last, string.length())) {
+
+		// skip the colon. index is now the first char of the value part.
+		typeFirstNonValidCharIndex++;
+		if (!validateValue(string, typeFirstNonValidCharIndex, string.length())) {
 			return -1;
 		}
-		return last;
+
+		return typeFirstNonValidCharIndex;
 	}
 }

--- a/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
+++ b/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
@@ -199,4 +199,38 @@ public class DefaultNetexIdValidator implements NetexIdValidator {
 		return true;
 	}
 
+	/**
+	 *
+	 * Validate codespace and type.
+	 *
+	 * @param string netex id
+	 * @return -1 if the id is invalid, otherwise the index of the value part within the id (the character index after the second colon).
+	 */
+
+	protected int validateToValueIndex(CharSequence string) {
+		if (string == null) {
+			return -1;
+		}
+
+		// minimum size is XXX:X:X
+		if (string.length() < NETEX_ID_MINIMUM_LENGTH) {
+			return -1;
+		}
+		if (string.charAt(NETEX_ID_CODESPACE_LENGTH) != ':') {
+			return -1;
+		}
+
+		int last = validateTypeToIndex(string, NETEX_ID_CODESPACE_LENGTH + 1);
+		if (last == -1 || string.charAt(last) != ':' || last <= NETEX_ID_CODESPACE_LENGTH + 1) {
+			return -1;
+		}
+		if (!validateCodespace(string, 0, NETEX_ID_CODESPACE_LENGTH)) {
+			return -1;
+		}
+		last++;
+		if (!validateValue(string, last, string.length())) {
+			return -1;
+		}
+		return last;
+	}
 }

--- a/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
+++ b/src/main/java/no/entur/abt/netex/id/DefaultNetexIdValidator.java
@@ -201,7 +201,7 @@ public class DefaultNetexIdValidator implements NetexIdValidator {
 
 	/**
 	 *
-	 * Validate codespace and type, return index useful for creating an id with the same codespace and type and another value.
+	 * Validate id, return index of value part (the character index after the second colon) if valid, otherwise -1.
 	 *
 	 * @param string netex id
 	 * @return -1 if the id is invalid, otherwise the index of the value part within the id (the character index after the second colon).

--- a/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
@@ -30,6 +30,8 @@ package no.entur.abt.netex.id;
 
 public class NetexIdBuilder {
 
+	private static DefaultNetexIdValidator VALIDATOR = DefaultNetexIdValidator.getInstance();
+
 	public static NetexIdBuilder newInstance() {
 		return new NetexIdBuilder();
 	}
@@ -45,6 +47,41 @@ public class NetexIdBuilder {
     public static NetexIdBuilder newInstance(String id) {
         return new NetexIdBuilder(id);
     }
+
+	/**
+	 * Create new id from an existing id + value part.
+	 *
+	 * @param id input id. codespace and type will be copied from this id.
+	 * @param valuePart new value part
+	 * @return an id with codespace and type from the id argument, value from the valuePart argument.
+	 */
+
+	public static String createIdFrom(String id, String valuePart) {
+		if(id == null) {
+			throw new IllegalArgumentException("Expected id");
+		}
+		if(valuePart == null) {
+			throw new IllegalArgumentException("Expected value");
+		}
+		int index = VALIDATOR.validateToValueIndex(id);
+		if(index == -1) {
+			throw NetexIdValidatingParser.getException(id);
+		}
+		return id.substring(0, index) + valuePart;
+	}
+
+	public static String createId(String codespace, String datatype, String value) {
+		if(!VALIDATOR.validateCodespace(codespace)) {
+			throw new IllegalArgumentException("'" + codespace + "' is not a valid codespace");
+		}
+		if(!VALIDATOR.validateType(datatype)) {
+			throw new IllegalArgumentException("'" + datatype + "' is not a valid datatype");
+		}
+		if(!VALIDATOR.validateValue(value)) {
+			throw new IllegalArgumentException("'" + value + "' is not a valid value");
+		}
+		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + datatype + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
+	}
 
     private final NetexIdValidator validator;
 

--- a/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
@@ -30,7 +30,7 @@ package no.entur.abt.netex.id;
 
 public class NetexIdBuilder {
 
-	private static DefaultNetexIdValidator VALIDATOR = DefaultNetexIdValidator.getInstance();
+	private static final DefaultNetexIdValidator VALIDATOR = DefaultNetexIdValidator.getInstance();
 
 	public static NetexIdBuilder newInstance() {
 		return new NetexIdBuilder();

--- a/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
@@ -60,6 +60,9 @@ public class NetexIdBuilder {
 		if(id == null) {
 			throw new IllegalArgumentException("Expected id");
 		}
+		if(valuePart == null) {
+			throw new IllegalArgumentException("Expected value");
+		}
 		if(!VALIDATOR.validateValue(valuePart)) {
 			throw new IllegalArgumentException("'" + valuePart + "' is not a valid value");
 		}

--- a/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
@@ -71,17 +71,17 @@ public class NetexIdBuilder {
 		return id.substring(0, index) + valuePart;
 	}
 
-	public static String createId(String codespace, String datatype, String value) {
+	public static String createId(String codespace, String type, String value) {
 		if(!VALIDATOR.validateCodespace(codespace)) {
 			throw new IllegalArgumentException("'" + codespace + "' is not a valid codespace");
 		}
-		if(!VALIDATOR.validateType(datatype)) {
-			throw new IllegalArgumentException("'" + datatype + "' is not a valid datatype");
+		if(!VALIDATOR.validateType(type)) {
+			throw new IllegalArgumentException("'" + type + "' is not a valid type");
 		}
 		if(!VALIDATOR.validateValue(value)) {
 			throw new IllegalArgumentException("'" + value + "' is not a valid value");
 		}
-		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + datatype + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
+		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + type + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
 	}
 
     private final NetexIdValidator validator;

--- a/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
@@ -60,9 +60,10 @@ public class NetexIdBuilder {
 		if(id == null) {
 			throw new IllegalArgumentException("Expected id");
 		}
-		if(valuePart == null) {
-			throw new IllegalArgumentException("Expected value");
+		if(!VALIDATOR.validateValue(valuePart)) {
+			throw new IllegalArgumentException("'" + valuePart + "' is not a valid value");
 		}
+
 		int index = VALIDATOR.validateToValueIndex(id);
 		if(index == -1) {
 			throw NetexIdValidatingParser.getException(id);

--- a/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
@@ -59,17 +59,17 @@ public class NetexIdNonValidatingBuilder {
 		return id.substring(0, index + 1) + valuePart;
 	}
 
-	public static String createId(String codespace, String datatype, String value) {
+	public static String createId(String codespace, String type, String value) {
 		if(codespace == null) {
 			throw new IllegalArgumentException("Codespace must not be null");
 		}
-		if(datatype == null) {
-			throw new IllegalArgumentException("Datatype must not be null");
+		if(type == null) {
+			throw new IllegalArgumentException("Type must not be null");
 		}
 		if(value == null) {
 			throw new IllegalArgumentException("Value must not be null");
 		}
-		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + datatype + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
+		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + type + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
 	}
 
 	public static NetexIdNonValidatingBuilder newInstance(String id) {

--- a/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
@@ -35,6 +35,41 @@ public class NetexIdNonValidatingBuilder {
 		return new NetexIdNonValidatingBuilder();
 	}
 
+	/**
+	 * Create new id from an existing id + value part.
+	 *
+	 * @param id input id. codespace and type will be copied from this id.
+	 * @param valuePart new value part
+	 * @return an id with codespace and type from the id argument, value from the valuePart argument.
+	 */
+
+	public static String createIdFrom(String id, String valuePart) {
+		if(id == null) {
+			throw new IllegalArgumentException("Expected id");
+		}
+		if(valuePart == null) {
+			throw new IllegalArgumentException("Expected value");
+		}
+		int index = id.lastIndexOf(DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR);
+		if(index == -1) {
+			throw NetexIdValidatingParser.getException(id);
+		}
+		return id.substring(0, index + 1) + valuePart;
+	}
+
+	public static String createId(String codespace, String datatype, String value) {
+		if(codespace == null) {
+			throw new IllegalArgumentException("Codespace must not be null");
+		}
+		if(datatype == null) {
+			throw new IllegalArgumentException("Datatype must not be null");
+		}
+		if(value == null) {
+			throw new IllegalArgumentException("Value must not be null");
+		}
+		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + datatype + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
+	}
+
 	protected String codespace;
 	protected String type;
 	protected String value;

--- a/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
@@ -102,7 +102,7 @@ public class NetexIdNonValidatingBuilder {
 		if (value == null) {
 			throw new IllegalStateException("Expected value (nonempty with characters A-Z, a-z, ø, Ø, æ, Æ, å, Å, underscore, \\ and -)");
 		}
-		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + type + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
+		return createId(codespace, type, value);
 	}
 
 }

--- a/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
@@ -46,29 +46,11 @@ public class NetexIdNonValidatingBuilder {
 	 */
 
 	public static String createIdFrom(String id, String valuePart) {
-		if(id == null) {
-			throw new IllegalArgumentException("Expected id");
-		}
-		if(valuePart == null) {
-			throw new IllegalArgumentException("Expected value");
-		}
 		int index = id.lastIndexOf(DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR);
-		if(index == -1) {
-			throw NetexIdValidatingParser.getException(id);
-		}
 		return id.substring(0, index + 1) + valuePart;
 	}
 
 	public static String createId(String codespace, String type, String value) {
-		if(codespace == null) {
-			throw new IllegalArgumentException("Codespace must not be null");
-		}
-		if(type == null) {
-			throw new IllegalArgumentException("Type must not be null");
-		}
-		if(value == null) {
-			throw new IllegalArgumentException("Value must not be null");
-		}
 		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + type + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
 	}
 

--- a/src/main/java/no/entur/abt/netex/id/NetexIdValidatingParser.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdValidatingParser.java
@@ -34,28 +34,19 @@ public class NetexIdValidatingParser extends DefaultNetexIdValidator implements 
 
 
 	public String getType(CharSequence string) {
-		int last = validateToIndex(string);
-		return string.subSequence(DefaultNetexIdValidator.NETEX_ID_CODESPACE_LENGTH + 1, last).toString();
+		int valueIndex = validateToValueIndex(string);
+		if(valueIndex == -1) {
+			throw getException(string);
+		}
+		return string.subSequence(DefaultNetexIdValidator.NETEX_ID_CODESPACE_LENGTH + 1, valueIndex - 1).toString();
 	}
 
 	public String getValue(CharSequence string) {
-		int last = validateToIndex(string);
-		return string.subSequence(last + 1, string.length()).toString();
-	}
-
-	private int validateToIndex(CharSequence string) {
-		// inline validation
-		if (string == null || string.length() < NETEX_ID_MINIMUM_LENGTH || string.charAt(NETEX_ID_CODESPACE_LENGTH) != ':') {
+		int valueIndex = validateToValueIndex(string);
+		if(valueIndex == -1) {
 			throw getException(string);
 		}
-		int index = validateTypeToIndex(string, NETEX_ID_CODESPACE_LENGTH + 1);
-		if(index == -1 || string.charAt(index) != ':' || index <= NETEX_ID_CODESPACE_LENGTH + 1
-				|| !validateCodespace(string, 0, NETEX_ID_CODESPACE_LENGTH)
-				|| !validateValue(string, index + 1, string.length())
-		) {
-			throw getException(string);
-		}
-		return index;
+		return string.subSequence(valueIndex, string.length()).toString();
 	}
 
 	private void assertValid(CharSequence id) {

--- a/src/test/java/no/entur/abt/netex/id/DefaultNetexIdValidatorTest.java
+++ b/src/test/java/no/entur/abt/netex/id/DefaultNetexIdValidatorTest.java
@@ -155,4 +155,19 @@ public class DefaultNetexIdValidatorTest {
 		assertFalse(defaultNetexIdValidator.validate("AAA::XXXXX"));
 	}
 
+	@Test
+	public void testValidateToValueIndex() {
+		assertEquals(defaultNetexIdValidator.validateToValueIndex(null), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC:DEF"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC:DEF:GH"), 8);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC:DEF!GH"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC!DEF:GH"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABCD:DEF:GH"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABCD:123:GH"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("123:DEF:GH"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC:DEF:"), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC:DEF:..."), -1);
+		assertEquals(defaultNetexIdValidator.validateToValueIndex("ABC::GH"), -1);
+	}
 }

--- a/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
@@ -144,6 +144,7 @@ public class NetexIdBuilderTest {
         assertThrows(IllegalArgumentException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:123", ".."));
     }
 
+    @Test
     public void testCreateFromInvalidIdPart() {
         assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:..", "12345"));
     }

--- a/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
@@ -26,6 +26,7 @@ package no.entur.abt.netex.id;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 import org.junit.jupiter.api.Test;
 
 public class NetexIdBuilderTest {
@@ -73,4 +74,69 @@ public class NetexIdBuilderTest {
     public void testBuilderFromExistingIdValue() {
         assertEquals("AAA:Network:456", NetexIdBuilder.newInstance("AAA:Network:123").withValue("456").build());
     }
+
+    @Test
+    public void testBuilderFromNullId() {
+        assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.newInstance(null));
+    }
+
+    @Test
+    public void testBuilderFromInvalidId() {
+        assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.newInstance("AA:B"));
+    }
+
+    @Test
+    public void testCreateCodespace() {
+        String build = NetexIdBuilder.createId("AAA", "Network", "123");
+        assertEquals("AAA:Network:123", build);
+    }
+
+    @Test
+    public void testCreateInvalidCodespaceInput() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId(null,"Network", "123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId("AAA", null, "123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId("AAA", "Network", null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId("AA", "Network", "123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId("AAAA", "Network", "123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId("AAA", "", "123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId("AAA", "Network", "");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdBuilder.createId("AAA", "Network!", null);
+        });
+    }
+
+    @Test
+    public void testCreateFromExistingId() {
+        assertEquals("AAA:Network:456", NetexIdBuilder.createIdFrom("AAA:Network:123", "456"));
+    }
+
+    @Test
+    public void testCreateFromExistingIdValue() {
+        assertEquals("AAA:Network:456", NetexIdBuilder.newInstance("AAA:Network:123").withValue("456").build());
+    }
+
+    @Test
+    public void testCreateFromNullId() {
+        assertThrows(IllegalArgumentException.class, () -> NetexIdBuilder.createIdFrom(null, "adf"));
+    }
+
+    @Test
+    public void testCreateFromInvalidId() {
+        assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom("AA:B", "12345"));
+    }
+
 }

--- a/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
@@ -145,6 +145,11 @@ public class NetexIdBuilderTest {
     }
 
     @Test
+    public void testCreateFromNullValue() {
+        assertThrows(IllegalArgumentException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:123", null));
+    }
+
+    @Test
     public void testCreateFromInvalidIdPart() {
         assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:..", "12345"));
     }

--- a/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
@@ -139,4 +139,13 @@ public class NetexIdBuilderTest {
         assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom("AA:B", "12345"));
     }
 
+    @Test
+    public void testCreateFromInvalidValue() {
+        assertThrows(IllegalArgumentException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:123", ".."));
+    }
+
+    public void testCreateFromInvalidIdPart() {
+        assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:..", "12345"));
+    }
+
 }

--- a/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
@@ -74,34 +74,7 @@ public class NetexIdNonValidatingBuilderTest {
     }
 
     @Test
-    public void testCreateInvalidCodespaceInput() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            NetexIdNonValidatingBuilder.createId(null,"Network", "123");
-        });
-        assertThrows(IllegalArgumentException.class, () -> {
-            NetexIdNonValidatingBuilder.createId("AAA", null, "123");
-        });
-        assertThrows(IllegalArgumentException.class, () -> {
-            NetexIdNonValidatingBuilder.createId("AAA", "Network", null);
-        });
-    }
-
-
-    @Test
     public void testCreateFromExistingId() {
         assertEquals("AAA:Network:456", NetexIdNonValidatingBuilder.createIdFrom("AAA:Network:123", "456"));
-    }
-
-    @Test
-    public void testCreateFromExistingIdNull() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            NetexIdNonValidatingBuilder.createIdFrom(null,"123");
-        });
-        assertThrows(IllegalArgumentException.class, () -> {
-            NetexIdNonValidatingBuilder.createIdFrom("AAA:Network:123",null);
-        });
-        assertThrows(IllegalNetexIDException.class, () -> {
-            NetexIdNonValidatingBuilder.createIdFrom("AAANetwork123","12345");
-        });
     }
 }

--- a/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
@@ -49,4 +49,29 @@ public class NetexIdNonValidatingBuilderTest {
         });
     }
 
+    @Test
+    public void testCreateCodespace() {
+        String build = NetexIdNonValidatingBuilder.createId("AAA", "Network", "123");
+        assertEquals("AAA:Network:123", build);
+    }
+
+    @Test
+    public void testCreateInvalidCodespaceInput() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdNonValidatingBuilder.createId(null,"Network", "123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdNonValidatingBuilder.createId("AAA", null, "123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdNonValidatingBuilder.createId("AAA", "Network", null);
+        });
+    }
+
+
+    @Test
+    public void testCreateFromExistingId() {
+        assertEquals("AAA:Network:456", NetexIdNonValidatingBuilder.createIdFrom("AAA:Network:123", "456"));
+    }
+
 }

--- a/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
@@ -23,6 +23,7 @@ package no.entur.abt.netex.id;
  * #L%
  */
 
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -91,4 +92,16 @@ public class NetexIdNonValidatingBuilderTest {
         assertEquals("AAA:Network:456", NetexIdNonValidatingBuilder.createIdFrom("AAA:Network:123", "456"));
     }
 
+    @Test
+    public void testCreateFromExistingIdNull() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdNonValidatingBuilder.createIdFrom(null,"123");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            NetexIdNonValidatingBuilder.createIdFrom("AAA:Network:123",null);
+        });
+        assertThrows(IllegalNetexIDException.class, () -> {
+            NetexIdNonValidatingBuilder.createIdFrom("AAANetwork123","12345");
+        });
+    }
 }

--- a/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdCreateBenchmark.java
+++ b/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdCreateBenchmark.java
@@ -24,6 +24,7 @@ package no.entur.abt.netex.id.jmh;
  */
 
 import no.entur.abt.netex.id.NetexIdBuilder;
+import no.entur.abt.netex.id.NetexIdNonValidatingBuilder;
 import no.entur.abt.netex.utils.NetexIdUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -62,14 +63,45 @@ public class NetexIdCreateBenchmark {
     }
 
     @Benchmark
-    public String createFromExistingId() {
+    public String createFromExistingIdBuilderValidate() {
         return NetexIdBuilder.newInstance("XXX:SecurityPolicy:æøåÆØÅ").withValue("abc").build();
     }
 
     @Benchmark
-    public String createId() {
+    public String createIdBuilderValidate() {
         return NetexIdBuilder.newInstance().withCodespace("XXX").withType("SecurityPolicy").withValue("æøåÆØÅ").build();
     }
+
+    @Benchmark
+    public String createFromExistingIdOnelinerValidate() {
+        return NetexIdBuilder.createIdFrom("XXX:SecurityPolicy:æøåÆØÅ", "abc");
+    }
+
+    @Benchmark
+    public String createIdOnelinerValidate() {
+        return NetexIdBuilder.createId("XXX", "SecurityPolicy", "æøåÆØÅ");
+    }
+
+    @Benchmark
+    public String createFromExistingIdBuilderNonvalidate() {
+        return NetexIdNonValidatingBuilder.newInstance("XXX:SecurityPolicy:æøåÆØÅ").withValue("abc").build();
+    }
+
+    @Benchmark
+    public String createIdBuilderNonvalidate() {
+        return NetexIdNonValidatingBuilder.newInstance().withCodespace("XXX").withType("SecurityPolicy").withValue("æøåÆØÅ").build();
+    }
+
+    @Benchmark
+    public String createFromExistingIdOnelinerNonvalidate() {
+        return NetexIdNonValidatingBuilder.createIdFrom("XXX:SecurityPolicy:æøåÆØÅ", "abc");
+    }
+
+    @Benchmark
+    public String createIdOnelinerNonvalidate() {
+        return NetexIdNonValidatingBuilder.createId("XXX", "SecurityPolicy", "æøåÆØÅ");
+    }
+
 
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()


### PR DESCRIPTION
Prepare for `NetexIdUtils` adjustments to `createId` and `createFrom` with one-liners in `NetexIdBuilder` / `NetexIdNonValidatingBuilder`.

This keeps the logic for creating ids in the builders. 


Somewhat accurate benchmarks:
```
Benchmark                                                        Mode  Cnt       Score       Error   Units
NetexIdCreateBenchmark.createFromExistingIdBuilderNonvalidate   thrpt    5   36546,654    307,546  ops/ms
NetexIdCreateBenchmark.createFromExistingIdBuilderValidate      thrpt    5   22451,858    301,643  ops/ms
NetexIdCreateBenchmark.createFromExistingIdNetexIdUtils         thrpt    5    1364,005    226,986  ops/ms
NetexIdCreateBenchmark.createFromExistingIdOnelinerNonvalidate  thrpt    5   99532,590    423,786  ops/ms
NetexIdCreateBenchmark.createFromExistingIdOnelinerValidate     thrpt    5   47947,087   1063,607  ops/ms
NetexIdCreateBenchmark.createIdBuilderNonvalidate               thrpt    5  214869,945  33608,535  ops/ms
NetexIdCreateBenchmark.createIdBuilderValidate                  thrpt    5   51605,133    541,030  ops/ms
NetexIdCreateBenchmark.createIdNetexIdUtils                     thrpt    5   40083,758    453,838  ops/ms
NetexIdCreateBenchmark.createIdOnelinerNonvalidate              thrpt    5  219833,660   2978,296  ops/ms
NetexIdCreateBenchmark.createIdOnelinerValidate                 thrpt    5   56191,782    810,540  ops/ms
```

=> one-liner non-validate is 2x-4x faster. 