### PR TITLE
Improve NetexIdUtils performance

### DIFF
--- a/.github/workflows/deploy-legacy-branch-manual.yml
+++ b/.github/workflows/deploy-legacy-branch-manual.yml
@@ -1,0 +1,18 @@
+name: Deploy legacy branch to Maven Central
+on:
+  workflow_dispatch
+
+jobs:
+  deploy-maven:
+    uses: entur/gha-maven-central/.github/workflows/maven-publish.yml@v1
+    secrets: inherit
+    permissions:
+      contents: write
+      issues: write
+    with:
+      next_version: minor
+      version_strategy: tag
+      version_tag_prefix: legacy-v
+      java_version: 25
+
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ String id = NetexIdBuilder.newInstance()
 // Validate
 NetexIdValidator validator = DefaultNetexIdValidator.getInstance();
 if (!validator.validate(id)) {
-    throw new IllegalArgumentException("Invalid NeTEx ID");
+    throw new IllegalNetexIDException("Invalid NeTEx ID");
 }
 
 // Parse

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ List<String> fareZones = ids.stream()
 
 ## NetexIdBuilder
 
-Build a validated ID from its parts. Throws `IllegalStateException` on invalid input.
+Build a validated ID from its parts. Throws `IllegalNetexIDException` on invalid input.
 
 ```java
 String id = NetexIdBuilder.newInstance()
@@ -80,7 +80,7 @@ NetexIdBuilder.newInstance()
     .withCodespace("AA")    // too short
     .withType("FareZone")
     .withValue("123")
-    .build();               // throws IllegalStateException
+    .build();               // throws IllegalNetexIDException
 ```
 
 ## NetexIdParser
@@ -158,7 +158,7 @@ List<String> result = ids.stream()
     .toList();
 ```
 
-Invalid codespace or type strings throw `IllegalStateException` at build time.
+Invalid codespace or type strings throw `IllegalNetexIDException` at build time.
 
 ## NetexIdValidator
 
@@ -173,9 +173,8 @@ validator.validateType("FareZone");        // true
 validator.validateValue("123");            // true
 ```
 
-## NetexIdUtils (legacy)
-
-> ⚠️ **`NetexIdUtils` is considerably slower than the modern APIs** — benchmarks show parsing and validation to be ~25–33× slower due to regexp-based validation. Prefer `NetexIdParser`, `NetexIdValidator`, and `NetexIdBuilder` for any performance-sensitive code.
+## NetexIdUtils
+One-liner helpers with validation.
 
 ```java
 String id = NetexIdUtils.createId("AAA", "FareZone", "123");
@@ -199,16 +198,3 @@ JMH benchmarks are included. Run them with:
 ```bash
 mvn package && java -jar target/netex-utils-*-perf-tests.jar
 ```
-
-Results from the included benchmark runs (ops/ms, higher is better):
-
-| Operation | Modern API | `NetexIdUtils` | Ratio |
-|---|---|---|---|
-| Get codespace | 6 005 | 236 | ~25× |
-| Get type | 7 615 | 228 | ~33× |
-| Get value | 5 797 | 226 | ~26× |
-| Validate ID | 7 707 | 247 | ~31× |
-| Create ID from existing | 27 496 | 1 575 | ~17× |
-| Create ID from parts | 63 906 | 51 561 | ~1.2× |
-
-Measured on a single machine; results will vary by JVM and hardware.

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
                         <release>
                             <github>
                                 <skipTag>false</skipTag>
-                                <skipRelease>true</skipRelease>
+                                <skipRelease>false</skipRelease>
                             </github>
                         </release>
                     </jreleaser>

--- a/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdBuilder.java
@@ -22,6 +22,8 @@ package no.entur.abt.netex.id;
  * #L%
  */
 
+import no.entur.abt.netex.utils.IllegalNetexIDException;
+
 /**
  * 
  * Build a Netex id. Includes validation.
@@ -58,13 +60,13 @@ public class NetexIdBuilder {
 
 	public static String createIdFrom(String id, String valuePart) {
 		if(id == null) {
-			throw new IllegalArgumentException("Expected id");
+			throw new IllegalNetexIDException("Expected id");
 		}
 		if(valuePart == null) {
-			throw new IllegalArgumentException("Expected value");
+			throw new IllegalNetexIDException("Expected value");
 		}
 		if(!VALIDATOR.validateValue(valuePart)) {
-			throw new IllegalArgumentException("'" + valuePart + "' is not a valid value");
+			throw new IllegalNetexIDException("'" + valuePart + "' is not a valid value");
 		}
 
 		int index = VALIDATOR.validateToValueIndex(id);
@@ -76,13 +78,13 @@ public class NetexIdBuilder {
 
 	public static String createId(String codespace, String type, String value) {
 		if(!VALIDATOR.validateCodespace(codespace)) {
-			throw new IllegalArgumentException("'" + codespace + "' is not a valid codespace");
+			throw new IllegalNetexIDException("'" + codespace + "' is not a valid codespace");
 		}
 		if(!VALIDATOR.validateType(type)) {
-			throw new IllegalArgumentException("'" + type + "' is not a valid type");
+			throw new IllegalNetexIDException("'" + type + "' is not a valid type");
 		}
 		if(!VALIDATOR.validateValue(value)) {
-			throw new IllegalArgumentException("'" + value + "' is not a valid value");
+			throw new IllegalNetexIDException("'" + value + "' is not a valid value");
 		}
 		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + type + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
 	}
@@ -137,13 +139,13 @@ public class NetexIdBuilder {
 
 	public String build() {
 		if (codespace == null || !validator.validateCodespace(codespace)) {
-			throw new IllegalStateException("Expected codespace (size 3 with characters A-Z), found " + codespace);
+			throw new IllegalNetexIDException("Expected codespace (size 3 with characters A-Z), found " + codespace);
 		}
 		if (type == null || !validator.validateType(type)) {
-			throw new IllegalStateException("Expected type (nonempty with characters A-Z or a-z), found " + type);
+			throw new IllegalNetexIDException("Expected type (nonempty with characters A-Z or a-z), found " + type);
 		}
 		if (value == null || !validator.validateValue(value)) {
-			throw new IllegalStateException("Expected value (nonempty with characters A-Z, a-z, ø, Ø, æ, Æ, å, Å, underscore, \\ and -), found " + value);
+			throw new IllegalNetexIDException("Expected value (nonempty with characters A-Z, a-z, ø, Ø, æ, Æ, å, Å, underscore, \\ and -), found " + value);
 		}
 		return codespace + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + type + DefaultNetexIdValidator.NETEX_ID_SEPARATOR_CHAR + value;
 	}

--- a/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilder.java
@@ -64,7 +64,7 @@ public class NetexIdNonValidatingBuilder {
 
 	public NetexIdNonValidatingBuilder(String id) {
 		if(id == null) {
-			throw new IllegalArgumentException("Expected id");
+			throw new IllegalNetexIDException("Expected id");
 		}
 		// use id as template
 		NetexIdNonvalidatingParser parser = NetexIdNonvalidatingParser.getInstance();
@@ -94,13 +94,13 @@ public class NetexIdNonValidatingBuilder {
 
 	public String build() {
 		if (codespace == null) {
-			throw new IllegalStateException("Expected codespace (size 3 with characters A-Z)");
+			throw new IllegalNetexIDException("Expected codespace (size 3 with characters A-Z)");
 		}
 		if (type == null) {
-			throw new IllegalStateException("Expected type (nonempty with characters A-Z or a-z)");
+			throw new IllegalNetexIDException("Expected type (nonempty with characters A-Z or a-z)");
 		}
 		if (value == null) {
-			throw new IllegalStateException("Expected value (nonempty with characters A-Z, a-z, ø, Ø, æ, Æ, å, Å, underscore, \\ and -)");
+			throw new IllegalNetexIDException("Expected value (nonempty with characters A-Z, a-z, ø, Ø, æ, Æ, å, Å, underscore, \\ and -)");
 		}
 		return createId(codespace, type, value);
 	}

--- a/src/main/java/no/entur/abt/netex/id/NetexIdValidatingParser.java
+++ b/src/main/java/no/entur/abt/netex/id/NetexIdValidatingParser.java
@@ -26,6 +26,12 @@ import no.entur.abt.netex.utils.IllegalNetexIDException;
  */
 public class NetexIdValidatingParser extends DefaultNetexIdValidator implements NetexIdParser {
 
+	private final static NetexIdValidatingParser INSTANCE = new NetexIdValidatingParser();
+
+	public static NetexIdValidatingParser getInstance() {
+		return INSTANCE;
+	}
+
 	public String getCodespace(CharSequence id) {
 		assertValid(id);
 		CharSequence result = id.subSequence(0, DefaultNetexIdValidator.NETEX_ID_CODESPACE_LENGTH);

--- a/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypePredicate.java
+++ b/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypePredicate.java
@@ -1,6 +1,7 @@
 package no.entur.abt.netex.id.predicate;
 
 import no.entur.abt.netex.id.DefaultNetexIdValidator;
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 
 /*-
  * #%L
@@ -38,10 +39,10 @@ public class NetexIdCodespaceTypePredicate implements NetexIdPredicate {
 
 	public NetexIdCodespaceTypePredicate(CharSequence codespace, CharSequence type) {
 		if (codespace.length() != DefaultNetexIdValidator.NETEX_ID_CODESPACE_LENGTH) {
-			throw new IllegalArgumentException();
+			throw new IllegalNetexIDException("'" + codespace + "' is not a valid codespace");
 		}
 		if (type.length() == 0) {
-			throw new IllegalArgumentException();
+			throw new IllegalNetexIDException("'" + type + "' is not a valid type");
 		}
 
 		char[] chars = new char[1 + codespace.length() + type.length()];

--- a/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypePredicate.java
+++ b/src/main/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypePredicate.java
@@ -38,10 +38,10 @@ public class NetexIdCodespaceTypePredicate implements NetexIdPredicate {
 	protected final char[] codespaceColonType; // ABC:DEFGH
 
 	public NetexIdCodespaceTypePredicate(CharSequence codespace, CharSequence type) {
-		if (codespace.length() != DefaultNetexIdValidator.NETEX_ID_CODESPACE_LENGTH) {
+		if (codespace == null || codespace.length() != DefaultNetexIdValidator.NETEX_ID_CODESPACE_LENGTH) {
 			throw new IllegalNetexIDException("'" + codespace + "' is not a valid codespace");
 		}
-		if (type.length() == 0) {
+		if (type == null || type.length() == 0) {
 			throw new IllegalNetexIDException("'" + type + "' is not a valid type");
 		}
 

--- a/src/main/java/no/entur/abt/netex/id/predicate/NetexIdPredicateBuilder.java
+++ b/src/main/java/no/entur/abt/netex/id/predicate/NetexIdPredicateBuilder.java
@@ -25,6 +25,7 @@ package no.entur.abt.netex.id.predicate;
 
 import no.entur.abt.netex.id.DefaultNetexIdValidator;
 import no.entur.abt.netex.id.NetexIdValidator;
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 
 /**
  * 
@@ -61,10 +62,10 @@ public class NetexIdPredicateBuilder {
 
 	public NetexIdPredicate build() {
 		if (codespace != null && !validator.validateCodespace(codespace)) {
-			throw new IllegalStateException("Expected codespace (size 3 with characters A-Z), found " + codespace);
+			throw new IllegalNetexIDException("Expected codespace (size 3 with characters A-Z), found " + codespace);
 		}
 		if (type != null && !validator.validateType(type)) {
-			throw new IllegalStateException("Expected type (nonempty with characters A-Z or a-z), found " + type);
+			throw new IllegalNetexIDException("Expected type (nonempty with characters A-Z or a-z), found " + type);
 		}
 
 		if(validate) {
@@ -75,7 +76,7 @@ public class NetexIdPredicateBuilder {
 			} else if (type != null) {
 				return new NetexIdTypeValidatingPredicate(type);
 			} else {
-				throw new IllegalStateException("Expected codespace and/or type");
+				throw new IllegalNetexIDException("Expected codespace and/or type");
 			}
 		}
 
@@ -86,7 +87,7 @@ public class NetexIdPredicateBuilder {
 		} else if (type != null) {
 			return new NetexIdTypePredicate(type);
 		} else {
-			throw new IllegalStateException("Expected codespace and/or type");
+			throw new IllegalNetexIDException("Expected codespace and/or type");
 		}
 
 	}

--- a/src/main/java/no/entur/abt/netex/utils/IllegalNetexIDException.java
+++ b/src/main/java/no/entur/abt/netex/utils/IllegalNetexIDException.java
@@ -23,7 +23,7 @@ package no.entur.abt.netex.utils;
  * #L%
  */
 
-public class IllegalNetexIDException extends RuntimeException {
+public class IllegalNetexIDException extends IllegalArgumentException {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdBuilderTest.java
@@ -39,28 +39,28 @@ public class NetexIdBuilderTest {
 
 	@Test
 	public void testInvalidCodespaceInput() {
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withType("Network").withValue("123").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withCodespace("AAA").withValue("123").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withCodespace("AAA").withType("Network").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withCodespace("AA").withType("Network").withValue("123").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withCodespace("AAAA").withType("Network").withValue("123").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withCodespace("AAA").withType("").withValue("123").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withCodespace("AAA").withType("Network").withValue("").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdBuilder.newInstance().withCodespace("AAA").withType("Network!").build();
 		});
 	}
@@ -93,28 +93,28 @@ public class NetexIdBuilderTest {
 
     @Test
     public void testCreateInvalidCodespaceInput() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId(null,"Network", "123");
         });
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId("AAA", null, "123");
         });
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId("AAA", "Network", null);
         });
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId("AA", "Network", "123");
         });
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId("AAAA", "Network", "123");
         });
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId("AAA", "", "123");
         });
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId("AAA", "Network", "");
         });
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdBuilder.createId("AAA", "Network!", null);
         });
     }
@@ -131,7 +131,7 @@ public class NetexIdBuilderTest {
 
     @Test
     public void testCreateFromNullId() {
-        assertThrows(IllegalArgumentException.class, () -> NetexIdBuilder.createIdFrom(null, "adf"));
+        assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom(null, "adf"));
     }
 
     @Test
@@ -141,12 +141,12 @@ public class NetexIdBuilderTest {
 
     @Test
     public void testCreateFromInvalidValue() {
-        assertThrows(IllegalArgumentException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:123", ".."));
+        assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:123", ".."));
     }
 
     @Test
     public void testCreateFromNullValue() {
-        assertThrows(IllegalArgumentException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:123", null));
+        assertThrows(IllegalNetexIDException.class, () -> NetexIdBuilder.createIdFrom("AAA:Network:123", null));
     }
 
     @Test

--- a/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/NetexIdNonValidatingBuilderTest.java
@@ -49,20 +49,20 @@ public class NetexIdNonValidatingBuilderTest {
 
     @Test
     public void testBuilderFromNullId() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdNonValidatingBuilder.newInstance(null).build();
         });
     }
 
     @Test
     public void testInvalidCodespaceInput() {
-        assertThrows(IllegalStateException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdNonValidatingBuilder.newInstance().withType("Network").withValue("123").build();
         });
-        assertThrows(IllegalStateException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdNonValidatingBuilder.newInstance().withCodespace("AAA").withValue("123").build();
         });
-        assertThrows(IllegalStateException.class, () -> {
+        assertThrows(IllegalNetexIDException.class, () -> {
             NetexIdNonValidatingBuilder.newInstance().withCodespace("AAA").withType("Network").build();
         });
     }

--- a/src/test/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypePredicateTest.java
+++ b/src/test/java/no/entur/abt/netex/id/predicate/NetexIdCodespaceTypePredicateTest.java
@@ -33,10 +33,10 @@ public class NetexIdCodespaceTypePredicateTest {
 
 	@Test
 	public void testConstructor() {
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			new NetexIdCodespaceTypePredicate("AB", "x");
 		});
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			new NetexIdCodespaceTypePredicate("ABC", "");
 		});
 	}

--- a/src/test/java/no/entur/abt/netex/id/predicate/NetexIdPredicateBuilderTest.java
+++ b/src/test/java/no/entur/abt/netex/id/predicate/NetexIdPredicateBuilderTest.java
@@ -154,32 +154,32 @@ public class NetexIdPredicateBuilderTest {
 
 	@Test
 	public void testInvalidCodespaceInput() {
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withCodespace(null).build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withCodespace("").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withCodespace("AA").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withCodespace("AAAA").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withCodespace("aaa").build();
 		});
 	}
 
 	@Test
 	public void testInvalidTypeInput() {
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withType(null).build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withType("").build();
 		});
-		assertThrows(IllegalStateException.class, () -> {
+		assertThrows(IllegalNetexIDException.class, () -> {
 			NetexIdPredicateBuilder.newInstance().withType("Network!").build();
 		});
 	}
@@ -216,12 +216,12 @@ public class NetexIdPredicateBuilderTest {
 
 	@Test
 	public void testBuildWithoutCodespaceOrType() {
-		assertThrows(IllegalStateException.class, () -> NetexIdPredicateBuilder.newInstance().build());
+		assertThrows(IllegalNetexIDException.class, () -> NetexIdPredicateBuilder.newInstance().build());
 	}
 
 	@Test
 	public void testBuildWithValidateWithoutCodespaceOrType() {
-		assertThrows(IllegalStateException.class, () -> NetexIdPredicateBuilder.newInstance().withValidate(true).build());
+		assertThrows(IllegalNetexIDException.class, () -> NetexIdPredicateBuilder.newInstance().withValidate(true).build());
 	}
 
 	@Test

--- a/src/test/java/no/entur/abt/netex/utils/NetexIdUtilsTest.java
+++ b/src/test/java/no/entur/abt/netex/utils/NetexIdUtilsTest.java
@@ -107,4 +107,14 @@ public class NetexIdUtilsTest {
 	public void createFrom_whenInvalidThenThrowIllegalNetexIDException() {
 		assertThrows(IllegalNetexIDException.class, () -> NetexIdUtils.createFrom("XXX:FareContract", "abc"));
 	}
+
+	@Test
+	public void createId_whenValid_thenReturnId() {
+		assertEquals("XXX:FareContract:abc", NetexIdUtils.createId("XXX", "FareContract", "abc"));
+	}
+
+	@Test
+	public void createId_whenInvalidThenThrowIllegalNetexIDException() {
+		assertThrows(IllegalNetexIDException.class, () -> NetexIdUtils.createId("XXX", "1234", "abc"));
+	}
 }

--- a/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
+++ b/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
@@ -186,6 +186,7 @@ public class NetexIdFacadeBenchmark {
         long count = 0;
         for (int i = 0; i < IDS.length; i++) {
             NetexIdUtils.assertValidOfType(IDS[i], IDS_PARTS[i][1]);
+            count++;
         }
         return count;
     }
@@ -195,6 +196,7 @@ public class NetexIdFacadeBenchmark {
         long count = 0;
         for (int i = 0; i < IDS.length; i++) {
             no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.assertValidOfType(IDS[i], IDS_PARTS[i][1]);
+            count++;
         }
         return count;
     }

--- a/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
+++ b/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
@@ -1,0 +1,210 @@
+package no.entur.abt.netex.id.jmh;
+
+/*-
+ * #%L
+ * Netex utils
+ * %%
+ * Copyright (C) 2019 - 2026 Entur
+ * %%
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ * 
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl5
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ * #L%
+ */
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import no.entur.abt.netex.utils.NetexIdUtils;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(time = 3, timeUnit = TimeUnit.SECONDS, iterations = 1)
+@Measurement(time = 3, timeUnit = TimeUnit.SECONDS, iterations = 1)
+@Timeout(timeUnit = TimeUnit.SECONDS, time = 4)
+@Fork(3)
+public class NetexIdFacadeBenchmark {
+
+    private static String[] IDS = {
+            "TST:DatedServiceJourney:1-2020-01-02",
+            "TST:OperatingDay:2020-01-04",
+            "TST:FareZone:1",
+            "TST:UicOperatingPeriod:SchoolDays",
+            "TST:ServiceCalendarFrame:ServiceCalendar-2021",
+            "SJN:JourneyPattern:1_2058545094_1_1_1_1_1_1_79",
+            "XXX:SecurityPolicy:æøåÆØÅ",
+            "SJN:Operator:LineOperator",
+            "SJN:Line:79",
+            "SJN:ServiceJourney:SJN_1787_2021_12_07_NORD",
+            "NSR:Quay:290",
+            "TST:StopPointInJourneyPattern:1",
+            "OPP:DistanceMatrixElement:TariffZone320to321",
+            "OST:ValidableElement:CarFerry-CarLessThan6m"
+    };
+
+    private static String[][] IDS_PARTS;
+
+    static {
+        IDS_PARTS = new String[IDS.length][];
+        for(int i = 0; i < IDS.length; i++) {
+            IDS_PARTS[i] = new String[]{
+                    NetexIdUtils.getCodespace(IDS[i]),
+                    NetexIdUtils.getType(IDS[i]),
+                    NetexIdUtils.getValue(IDS[i])
+            };
+        }
+    }
+
+    @Benchmark
+    public long createId() {
+        long count = 0;
+        for (String[] parts : IDS_PARTS) {
+            count += NetexIdUtils.createId(parts[0], parts[1], parts[2]).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long createIdRegexp() {
+        long count = 0;
+        for (String[] parts : IDS_PARTS) {
+            count += no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.createId(parts[0], parts[1], parts[2]).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long createFrom() {
+        long count = 0;
+        for (String id : IDS) {
+            count += NetexIdUtils.createFrom(id, "abc").length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long createFromRegexp() {
+        long count = 0;
+        for (String id : IDS) {
+            count += no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.createFrom(id, "abc").length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long getCodespace() {
+        long count = 0;
+        for (String id : IDS) {
+            count += NetexIdUtils.getCodespace(id).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long getCodespaceRegexp() {
+        long count = 0;
+        for (String id : IDS) {
+            count += no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.getCodespace(id).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long getType() {
+        long count = 0;
+        for (String id : IDS) {
+            count += NetexIdUtils.getType(id).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long getTypeRegexp() {
+        long count = 0;
+        for (String id : IDS) {
+            count += no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.getType(id).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long getValue() {
+        long count = 0;
+        for (String id : IDS) {
+            count += NetexIdUtils.getValue(id).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long getValueRegexp() {
+        long count = 0;
+        for (String id : IDS) {
+            count += no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.getValue(id).length();
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long isValid() {
+        long count = 0;
+        for (String id : IDS) {
+            count += NetexIdUtils.isValid(id) ? 1 : 0;
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long isValidRegexp() {
+        long count = 0;
+        for (String id : IDS) {
+            count += no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.isValid(id) ? 1 : 0;
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long assertValidOfType() {
+        long count = 0;
+        for (int i = 0; i < IDS.length; i++) {
+            NetexIdUtils.assertValidOfType(IDS[i], IDS_PARTS[i][1]);
+        }
+        return count;
+    }
+
+    @Benchmark
+    public long assertValidOfTypeRegexp() {
+        long count = 0;
+        for (int i = 0; i < IDS.length; i++) {
+            no.entur.abt.netex.id.jmh.legacy.NetexIdUtils.assertValidOfType(IDS[i], IDS_PARTS[i][1]);
+        }
+        return count;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(NetexIdFacadeBenchmark.class.getSimpleName())
+                .result("jmh-result-" + Instant.now().toString() + ".json")
+                .resultFormat(ResultFormatType.JSON)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
+++ b/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
@@ -27,7 +27,16 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import no.entur.abt.netex.utils.NetexIdUtils;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;

--- a/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
+++ b/src/test/perf/no/entur/abt/netex/id/jmh/NetexIdFacadeBenchmark.java
@@ -213,7 +213,7 @@ public class NetexIdFacadeBenchmark {
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .include(NetexIdFacadeBenchmark.class.getSimpleName())
-                .result("jmh-result-" + Instant.now().toString() + ".json")
+                .result("jmh-result-" + Instant.now().toEpochMilli() + ".json")
                 .resultFormat(ResultFormatType.JSON)
                 .build();
         new Runner(opt).run();

--- a/src/test/perf/no/entur/abt/netex/id/jmh/legacy/NetexIdUtils.java
+++ b/src/test/perf/no/entur/abt/netex/id/jmh/legacy/NetexIdUtils.java
@@ -1,4 +1,4 @@
-package no.entur.abt.netex.utils;
+package no.entur.abt.netex.id.jmh.legacy;
 
 /*-
  * #%L
@@ -23,62 +23,71 @@ package no.entur.abt.netex.utils;
  * #L%
  */
 
-import no.entur.abt.netex.id.NetexIdValidatingParser;
-import no.entur.abt.netex.id.NetexIdNonvalidatingParser;
-import no.entur.abt.netex.id.NetexIdBuilder;
+import no.entur.abt.netex.utils.IllegalNetexIDException;
 
 import java.util.Objects;
 
 public class NetexIdUtils {
+	private static final String NETEX_ID_SEPARATOR_CHAR = ":";
 
-	private static final NetexIdValidatingParser PARSER = NetexIdValidatingParser.getInstance();
-	private static final NetexIdNonvalidatingParser NON_VALIDATING_PARSER = NetexIdNonvalidatingParser.getInstance();
-
-	private NetexIdUtils() {
-		// utility class
-	}
+	private static final String ID_PATTERN = "^([A-Z]{3}):([A-Za-z]+):([0-9ÆØÅæøåA-Za-z_\\\\-]+)$";
 
 	public static String createId(String codespace, String datatype, String value) {
-		return NetexIdBuilder.createId(codespace, datatype, value);
+		return String.join(NETEX_ID_SEPARATOR_CHAR, codespace, datatype, value);
 	}
 
 	public static String getCodespace(String id) {
-		return PARSER.getCodespace(id);
+		assertValid(id);
+		return getField(id, 0);
 	}
 
 	public static String getType(String id) {
-		return PARSER.getType(id);
+		assertValid(id);
+		return getField(id, 1);
 	}
 
 	public static String getValue(String id) {
-		return PARSER.getValue(id);
+		assertValid(id);
+		return getField(id, 2);
 	}
 
 	public static boolean isValid(String id) {
-		return PARSER.validate(id);
+		return id != null && id.matches(ID_PATTERN);
 	}
 
 	public static void assertValidOfType(String id, String expectedType) {
 		assertValid(id);
-		if (!Objects.equals(NON_VALIDATING_PARSER.getType(id), expectedType)) {
+		if (!Objects.equals(getType(id), expectedType)) {
 			throw new IllegalNetexIDException(String.format("Value '%s' is not of expected type '%s'", id, expectedType));
 		}
 	}
 
 	public static void assertValid(String id) {
 		if (!isValid(id)) {
-			throw NetexIdValidatingParser.getException(id);
+			throw new IllegalNetexIDException(String.format(
+					"Value '%s' is not a valid NeTEx id according to profile. ID should be in the format Codespace:Type:Val (ie XYZ:FareContract:1231)", id));
+		}
+	}
+
+	private static String getField(String id, int index) {
+		try {
+			return id.split(NETEX_ID_SEPARATOR_CHAR)[index];
+		} catch (Exception e) {
+			throw new IllegalNetexIDException(String.format(
+					"Value '%s' is not a valid NeTEx id according to profile. ID should be in the format Codespace:Type:Val (ie XYZ:FareContract:1231)", id),
+					e);
 		}
 	}
 
 	/**
 	 * Create a new NeTEx id of same codespace and type but with new value part
-	 *
+	 * 
 	 * @param id        original netex id
 	 * @param valuePart value part of id
 	 * @return the newly constructed id
 	 */
 	public static String createFrom(String id, String valuePart) {
-		return NetexIdBuilder.createIdFrom(id, valuePart);
+		return createId(getCodespace(id), getType(id), valuePart);
+
 	}
 }


### PR DESCRIPTION
Adjust inner workings of `NetexIdUtils` for improved performance. Replaces https://github.com/entur/netex-utils/pull/242.

 * publishing as new major version to simplify rollback in case of troubles
 * Added JMH test (`Regexp` is the old version)
 * Breaking changes:
   * Adding validation in `NetexIdUtils.createId(..)` so that all `NetexIdUtils` methods (except `isValid(..)`) do validation (with `IllegalNetexIDException` for invalid ids).
   * Retire `IllegalStateException` / `IllegalArgumentException` in favour of `IllegalNetexIDException`

```
Benchmark                                        Mode  Cnt     Score      Error   Units
NetexIdFacadeBenchmark.assertValidOfType        thrpt    3  1946,485 ±  109,153  ops/ms
NetexIdFacadeBenchmark.assertValidOfTypeRegexp  thrpt    3    53,114 ±   29,639  ops/ms
NetexIdFacadeBenchmark.createFrom               thrpt    3  1598,741 ±  105,885  ops/ms
NetexIdFacadeBenchmark.createFromRegexp         thrpt    3    45,205 ±   33,852  ops/ms
NetexIdFacadeBenchmark.createId                 thrpt    3  1654,043 ±  189,373  ops/ms
NetexIdFacadeBenchmark.createIdRegexp           thrpt    3  1524,867 ± 1279,811  ops/ms
NetexIdFacadeBenchmark.getCodespace             thrpt    3  2830,557 ±   91,540  ops/ms
NetexIdFacadeBenchmark.getCodespaceRegexp       thrpt    3    98,019 ±   50,061  ops/ms
NetexIdFacadeBenchmark.getType                  thrpt    3  2451,926 ±  539,886  ops/ms
NetexIdFacadeBenchmark.getTypeRegexp            thrpt    3    98,513 ±   74,464  ops/ms
NetexIdFacadeBenchmark.getValue                 thrpt    3  2136,497 ±  111,000  ops/ms
NetexIdFacadeBenchmark.getValueRegexp           thrpt    3    91,716 ±   57,855  ops/ms
NetexIdFacadeBenchmark.isValid                  thrpt    3  3424,859 ±  101,611  ops/ms
NetexIdFacadeBenchmark.isValidRegexp            thrpt    3   119,915 ±   88,437  ops/ms
```

