### PR TITLE
Legacy: Log warning when calling createId(..) with invalid inputs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,16 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <slf4j.version>2.0.17</slf4j.version>
         <spotless.version>2.44.2</spotless.version>
     </properties>
     <dependencies>
+        <!-- Source: https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -42,6 +49,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/no/entur/abt/netex/utils/NetexIdUtils.java
+++ b/src/main/java/no/entur/abt/netex/utils/NetexIdUtils.java
@@ -23,6 +23,10 @@ package no.entur.abt.netex.utils;
  * #L%
  */
 
+import no.entur.abt.netex.id.DefaultNetexIdValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Objects;
 
 public class NetexIdUtils {
@@ -30,7 +34,20 @@ public class NetexIdUtils {
 
 	private static final String ID_PATTERN = "^([A-Z]{3}):([A-Za-z]+):([0-9ÆØÅæøåA-Za-z_\\\\-]+)$";
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(NetexIdUtils.class);
+
+	private static final DefaultNetexIdValidator VALIDATOR = DefaultNetexIdValidator.getInstance();
+
 	public static String createId(String codespace, String datatype, String value) {
+
+		boolean validCodespace = VALIDATOR.validateCodespace(codespace);
+		boolean validType = VALIDATOR.validateType(datatype);
+		boolean validValue = VALIDATOR.validateValue(value);
+
+		if(!validCodespace || !validType || !validValue) {
+			LOGGER.warn("Creating id from one or more invalid parts: Codespace '" + codespace + "', type '" + datatype + "' and value '" + value + "'.");
+		}
+
 		return String.join(NETEX_ID_SEPARATOR_CHAR, codespace, datatype, value);
 	}
 

--- a/src/test/java/no/entur/abt/netex/utils/NetexIdUtilsTest.java
+++ b/src/test/java/no/entur/abt/netex/utils/NetexIdUtilsTest.java
@@ -107,4 +107,11 @@ public class NetexIdUtilsTest {
 	public void createFrom_whenInvalidThenThrowIllegalNetexIDException() {
 		assertThrows(IllegalNetexIDException.class, () -> NetexIdUtils.createFrom("XXX:FareContract", "abc"));
 	}
+
+	@Test
+	public void createId_whenInvalidThenLogMessage() {
+		NetexIdUtils.createId("XXX", "1234", "abc");
+		NetexIdUtils.createId("XX", "ABC", "abc");
+		NetexIdUtils.createId("XXX", "ABC", "...");
+	}
 }


### PR DESCRIPTION
Make transistion to version 2 more predicatable. 

 * add SLF4J 
 * log warning on `NetexIdUtils.createId(..)` invalid inputs

Manally verified:
```
[main] WARN no.entur.abt.netex.utils.NetexIdUtils - Creating id from one or more invalid parts: Codespace 'XXX', type '1234' and value 'abc'.
[main] WARN no.entur.abt.netex.utils.NetexIdUtils - Creating id from one or more invalid parts: Codespace 'XX', type 'ABC' and value 'abc'.
[main] WARN no.entur.abt.netex.utils.NetexIdUtils - Creating id from one or more invalid parts: Codespace 'XXX', type 'ABC' and value '...'.
```