### PR TITLE
Revert createId(..) to previous behaviour; log warning instead of throwing exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,16 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <slf4j.version>2.0.17</slf4j.version>
         <spotless.version>2.44.2</spotless.version>
     </properties>
     <dependencies>
+        <!-- Source: https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -42,6 +49,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/no/entur/abt/netex/utils/NetexIdUtils.java
+++ b/src/main/java/no/entur/abt/netex/utils/NetexIdUtils.java
@@ -23,7 +23,13 @@ package no.entur.abt.netex.utils;
  * #L%
  */
 
-import no.entur.abt.netex.id.*;
+
+import no.entur.abt.netex.id.NetexIdValidatingParser;
+import no.entur.abt.netex.id.NetexIdNonvalidatingParser;
+import no.entur.abt.netex.id.NetexIdBuilder;
+import no.entur.abt.netex.id.DefaultNetexIdValidator;
+import no.entur.abt.netex.id.NetexIdNonValidatingBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/no/entur/abt/netex/utils/NetexIdUtils.java
+++ b/src/main/java/no/entur/abt/netex/utils/NetexIdUtils.java
@@ -23,9 +23,9 @@ package no.entur.abt.netex.utils;
  * #L%
  */
 
-import no.entur.abt.netex.id.NetexIdValidatingParser;
-import no.entur.abt.netex.id.NetexIdNonvalidatingParser;
-import no.entur.abt.netex.id.NetexIdBuilder;
+import no.entur.abt.netex.id.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 
@@ -33,13 +33,25 @@ public class NetexIdUtils {
 
 	private static final NetexIdValidatingParser PARSER = NetexIdValidatingParser.getInstance();
 	private static final NetexIdNonvalidatingParser NON_VALIDATING_PARSER = NetexIdNonvalidatingParser.getInstance();
+	private static final DefaultNetexIdValidator VALIDATOR = DefaultNetexIdValidator.getInstance();
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(NetexIdUtils.class);
 
 	private NetexIdUtils() {
 		// utility class
 	}
 
 	public static String createId(String codespace, String datatype, String value) {
-		return NetexIdBuilder.createId(codespace, datatype, value);
+
+		boolean validCodespace = VALIDATOR.validateCodespace(codespace);
+		boolean validType = VALIDATOR.validateType(datatype);
+		boolean validValue = VALIDATOR.validateValue(value);
+
+		if(!validCodespace || !validType || !validValue) {
+			LOGGER.warn("Creating id from one or more invalid parts: Codespace '" + codespace + "', type '" + datatype + "' and value '" + value + "'.");
+		}
+
+		return NetexIdNonValidatingBuilder.createId(codespace, datatype, value);
 	}
 
 	public static String getCodespace(String id) {

--- a/src/test/java/no/entur/abt/netex/utils/NetexIdUtilsTest.java
+++ b/src/test/java/no/entur/abt/netex/utils/NetexIdUtilsTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class NetexIdUtilsTest {
@@ -114,7 +115,16 @@ public class NetexIdUtilsTest {
 	}
 
 	@Test
+	@Disabled("Reenable later")
 	public void createId_whenInvalidThenThrowIllegalNetexIDException() {
 		assertThrows(IllegalNetexIDException.class, () -> NetexIdUtils.createId("XXX", "1234", "abc"));
+	}
+
+	// remove me later
+	@Test
+	public void createId_whenInvalidThenLogMessage() {
+		assertEquals("XXX:1234:abc", NetexIdUtils.createId("XXX", "1234", "abc"));
+		assertEquals("XX:ABC:abc", NetexIdUtils.createId("XX", "ABC", "abc"));
+		assertEquals("XXX:ABC:...", NetexIdUtils.createId("XXX", "ABC", "..."));
 	}
 }


### PR DESCRIPTION
Temporarily allow creating invalid ids.

```
[main] WARN no.entur.abt.netex.utils.NetexIdUtils - Creating id from one or more invalid parts: Codespace 'XXX', type '1234' and value 'abc'.
[main] WARN no.entur.abt.netex.utils.NetexIdUtils - Creating id from one or more invalid parts: Codespace 'XX', type 'ABC' and value 'abc'.
[main] WARN no.entur.abt.netex.utils.NetexIdUtils - Creating id from one or more invalid parts: Codespace 'XXX', type 'ABC' and value '...'.

```